### PR TITLE
OP9-3 : les champs employé étaient récupérés à la place des champs admin

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="PROJECT" libraries="{firebase-app, firebase-firestore, firebase-storage, jquery-3.2.1.slim, popper.js}" />
+  </component>
+</project>

--- a/src/containers/Login.js
+++ b/src/containers/Login.js
@@ -1,4 +1,3 @@
-
 import { ROUTES_PATH } from '../constants/routes.js'
 export let PREVIOUS_LOCATION = ''
 
@@ -15,6 +14,7 @@ export default class Login {
     const formAdmin = this.document.querySelector(`form[data-testid="form-admin"]`)
     formAdmin.addEventListener("submit", this.handleSubmitAdmin)
   }
+
   handleSubmitEmployee = e => {
     const user = {
       type: "Employee",
@@ -35,8 +35,8 @@ export default class Login {
   handleSubmitAdmin = e => {
     const user = {
       type: "Admin",
-      email: e.target.querySelector(`input[data-testid="employee-email-input"]`).value,
-      password: e.target.querySelector(`input[data-testid="employee-password-input"]`).value,
+      email: e.target.querySelector(`input[data-testid="admin-email-input"]`).value,
+      password: e.target.querySelector(`input[data-testid="admin-password-input"]`).value,
       status: "connected"
     }
     this.localStorage.setItem("user", JSON.stringify(user))
@@ -77,7 +77,7 @@ export default class Login {
       .doc(user.email)
       .set({
         type: user.type,
-        name: user.email.split('@')[0] 
+        name: user.email.split('@')[0]
       })
       .then(() => console.log(`User with ${user.email} is created`))
       .catch(error => error)
@@ -85,4 +85,4 @@ export default class Login {
       return null
     }
   }
-} 
+}


### PR DESCRIPTION
Les champs email et password passé à la fonction handleSubmitAdmin (Login.js) étaient récupérés au niveau des champs email et password de la page de connexion employé au lieu de celle de l'admin. Cela était du à une erreur de syntaxe au niveau de l'attribut data-testid passé au querySelector