### PR TITLE
OP9-2: les notes de frais sont triées par dates + problème format

### DIFF
--- a/src/containers/Bills.js
+++ b/src/containers/Bills.js
@@ -1,5 +1,5 @@
 import { ROUTES_PATH } from '../constants/routes.js'
-import { formatDate, formatStatus } from "../app/format.js"
+import { formatStatus } from "../app/format.js"
 import Logout from "./Logout.js"
 
 export default class {
@@ -41,12 +41,12 @@ export default class {
             try {
               return {
                 ...doc.data(),
-                date: formatDate(doc.data().date),
+                date: doc.data().date,
                 status: formatStatus(doc.data().status)
               }
             } catch(e) {
               // if for some reason, corrupted data was introduced, we manage here failing formatDate function
-              // log the error and return unformatted date in that case
+              // log the error and return no formatted date in that case
               console.log(e,'for',doc.data())
               return {
                 ...doc.data(),
@@ -56,7 +56,6 @@ export default class {
             }
           })
           .filter(bill => bill.email === userEmail)
-          console.log('length', bills.length)
         return bills
       })
       .catch(error => error)

--- a/src/views/BillsUI.js
+++ b/src/views/BillsUI.js
@@ -20,11 +20,11 @@ const row = (bill) => {
   }
 
 const rows = (data) => {
-  return (data && data.length) ? data.map(bill => row(bill)).join("") : ""
+  return (data && data.length) ? data.sort((d1, d2) => Date.parse(d2.date) - Date.parse(d1.date)).map(bill => row(bill)).join("") : ""
 }
 
 export default ({ data: bills, loading, error }) => {
-  
+
   const modal = () => (`
     <div class="modal fade" id="modaleFile" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
@@ -47,7 +47,7 @@ export default ({ data: bills, loading, error }) => {
   } else if (error) {
     return ErrorPage(error)
   }
-  
+
   return (`
     <div class='layout'>
       ${VerticalLayout(120)}


### PR DESCRIPTION
Afin de trier les notes de frais par dates, il faut effectuer la méthode .sort() sur le tableaux des bills avant d'appliquer la fonction formatDate() aux dates (car elle empêcherait la méthode Date.parse() de convertir les dates afin de les ordonnées ). 

Il était donc possible de régler ce problème seulement en modifiant Bill.js, en conservant le format initial et en reformatant les dates après avoir trier le tableau des bills.

Cependant, en conservant le format des dates tels qu'il existait, le test pour Bill.js ne passait pas. En effet, le test attends de trouver dans le HTML des dates non formatées.

Ainsi, malgré le fait qu'il était tout à fait possible de conserver le format de base, ce dernier a été retiré afin de répondre aux exigences du test. 
