### PR TITLE
OP9-5: pb avec le format de date + filtre par statut

### DIFF
--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -44,7 +44,7 @@ export const card = (bill) => {
         <span> ${bill.amount} € </span>
       </div>
       <div class='date-type-container'>
-        <span> ${formatDate(bill.date)} </span>
+        <span> ${bill.date} </span>
         <span> ${bill.type} </span>
       </div>
     </div>
@@ -105,9 +105,6 @@ export default class {
       $('.vertical-navbar').css({ height: '120vh' })
       this.counter ++
     }
-    $('#icon-eye-d').click(this.handleClickIconEye)
-    $('#btn-accept-bill').click((e) => this.handleAcceptSubmit(e, bill))
-    $('#btn-refuse-bill').click((e) => this.handleRefuseSubmit(e, bill))
   }
 
   handleAcceptSubmit = (e, bill) => {
@@ -140,12 +137,11 @@ export default class {
       this.counter ++
     } else {
       $(`#arrow-icon${this.index}`).css({ transform: 'rotate(90deg)'})
-      $(`#status-bills-container${this.index}`)
-        .html("")
+      $(`#status-bills-container${this.index}`).html("")
       this.counter ++
     }
 
-    bills.forEach(bill => {
+    bills.filter(bill => bill.status === getStatus(this.index)).forEach(bill => {
       $(`#open-bill${bill.id}`).click((e) => this.handleEditTicket(e, bill, bills))
     })
 
@@ -172,7 +168,7 @@ export default class {
       .catch(console.log)
     }
   }
-    
+
   // not need to cover this function by tests
   updateBill = (bill) => {
     if (this.firestore) {


### PR DESCRIPTION
Alors alors... 2 erreurs causaient le bug de sélection de ticket après dépliage de plusieurs catégories de liste.

Premièrement, il y avait encore un problème avec le formateDate qui causait une erreur console assez explicite. Le problème à ce niveau relève plus de la pertinence de vouloir conserver ce format (qui je vous le rappelle ne passait pas dans les attendus des tests Jest...). Pour l'instant j'ai retirer la fonction de formatage des dates mais cela pourrait être revue un peu plus tard. Je manque d'éléments explicite de description pour le format précis des dates et ce format ne passe pas les tests test Jest (histoire d'être sûr qu'on s'est bien compris).

Deuxièmement,  les problèmes ont vraiment commencés... 
Dans le code, un écouteur de l'évènement click est paramétré pour chacune des flèches dépliant un des trois menu (en attente, validé, refusé). 
A chaque click, le contenu de la liste est généré et un écouteur de clic est placé sur chacune des notes de frais.
Or, lorsqu'on dépliait les trois liste et qu'on activait les événements des clics au niveau de chaque note de frais, la liste étant dépliait en deuxième recevait 2 clics par note de frais activées et celle en troisième 3. 
Ainsi, les notes de frais de la deuxième liste recevant à chaque fois 2 clics étaient affichées puis cacher ce qui empêchait la visualisation de leur contenu. Si il y avait eu une 4ème catégorie elle aurait rencontré le même problème ! 
La difficulté, ici, est que l'on est face à une erreur silencieuse de logique. 
Cependant, on peut remarque un lien entre le nombre de onclick déclenchés au niveau des menu et le nombre d'écouteurs activés pour chaque notes de frais activées par menu ! Le problème venait donc du fait qu'à chaque onclick placé au niveau de la liste on parcourait l'ENSEMBLE des notes de frais au lieu de parcourir et de placé des onclick au niveau de chacune des notes de frais de la catégorie correspondant au menu sélectionné ! 
D'où, pour 2 menus sélectionnés les 2 onclicks par notes de frais, 3 menu 3 onclick par notes de frais et ainsi de suite. 
J'ai donc placé un filtre sur les statuts juste avant d'itérer sur les notes de frais pour placés les onclick et... MAGIE le bug a disparu !! 

PS : pour la ligne 107 je corrige ca juste après c'était un oublie